### PR TITLE
add support for nvhpc compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ find_package( Eigen3 REQUIRED NO_MODULE HINTS
               $ENV{Eigen3_PATH} $ENV{EIGEN3_PATH} $ENV{Eigen_PATH} $ENV{EIGEN_PATH} )
 find_package( gsl-lite REQUIRED HINTS $ENV{gsl_lite_DIR} )
 find_package( udunits 2.2.0 REQUIRED )
+find_package( EXPAT REQUIRED )
 find_package( Boost 1.64.0 REQUIRED )
 
 # Optional

--- a/src/engines/ioda/CMakeLists.txt
+++ b/src/engines/ioda/CMakeLists.txt
@@ -343,6 +343,7 @@ target_link_libraries(ioda_engines PUBLIC gsl::gsl-lite)
 target_link_libraries(ioda_engines PUBLIC Eigen3::Eigen)
 target_link_libraries(ioda_engines PUBLIC udunits::udunits)
 target_link_libraries(ioda_engines PUBLIC eckit)
+target_link_libraries(ioda_engines PUBLIC EXPAT::EXPAT)
 
 if(BUILD_PYTHON_BINDINGS)
 	target_link_libraries(ioda_engines PRIVATE Python3::Python pybind11::headers)

--- a/src/engines/ioda/include/ioda/Attributes/Attribute.h
+++ b/src/engines/ioda/include/ioda/Attributes/Attribute.h
@@ -104,7 +104,7 @@ public:
       auto d   = m.serialize(data);
       auto spn = gsl::make_span<const char>(reinterpret_cast<const char*>(d->DataPointers.data()),
                                             d->DataPointers.size() * Marshaller::bytesPerElement_);
-      write(spn, TypeWrapper::GetType(getTypeProvider()));
+      write(spn, TypeWrapper::GetType(gsl::not_null<const ::ioda::detail::Type_Provider*>(getTypeProvider())));
       return Attribute_Implementation{backend_};
     } catch (...) {
       std::throw_with_nested(Exception(ioda_Here()));
@@ -259,7 +259,7 @@ public:
       auto p = m.prep_deserialize(numObjects);
       read(gsl::make_span<char>(reinterpret_cast<char*>(p->DataPointers.data()),
                                 p->DataPointers.size() * Marshaller::bytesPerElement_),
-           TypeWrapper::GetType(getTypeProvider()));
+           TypeWrapper::GetType(gsl::not_null<const ::ioda::detail::Type_Provider*>(getTypeProvider())));
       m.deserialize(p, data);
 
       return Attribute_Implementation{backend_};
@@ -445,7 +445,7 @@ public:
   /// \throws ioda::Exception if an error occurred.
   template <class DataType>
   bool isA() const {
-    Type templateType = Types::GetType_Wrapper<DataType>::GetType(getTypeProvider());
+    Type templateType = Types::GetType_Wrapper<DataType>::GetType(gsl::not_null<const ::ioda::detail::Type_Provider*>(getTypeProvider()));
 
     return isA(templateType);
   }
@@ -453,7 +453,7 @@ public:
   virtual bool isA(Type lhs) const;
 
   /// Python compatability function
-  inline bool isA(BasicTypes dataType) { return isA(Type(dataType, getTypeProvider())); }
+  inline bool isA(BasicTypes dataType) { return isA(Type(dataType, gsl::not_null<::ioda::detail::Type_Provider*>(getTypeProvider()))); }
   /// \internal pybind11
   inline bool _py_isA2(BasicTypes dataType) { return isA(dataType); }
 

--- a/src/engines/ioda/include/ioda/Attributes/Has_Attributes.h
+++ b/src/engines/ioda/include/ioda/Attributes/Has_Attributes.h
@@ -332,7 +332,7 @@ public:
   /// Python compatability function
   inline Attribute _create_py(const std::string& attrname, BasicTypes dataType,
                               const std::vector<Dimensions_t>& dimensions = {1}) {
-    return create(attrname, ::ioda::Type(dataType, getTypeProvider()), dimensions);
+    return create(attrname, ::ioda::Type(dataType, gsl::not_null<::ioda::detail::Type_Provider*>(getTypeProvider())), dimensions);
   }
 
   /// \brief Create an Attribute without setting its data.
@@ -345,7 +345,7 @@ public:
   Attribute create(const std::string& attrname,
                    const std::vector<Dimensions_t>& dimensions = {1}) {
     try {
-      Type in_memory_dataType = TypeWrapper::GetType(getTypeProvider());
+      Type in_memory_dataType = TypeWrapper::GetType(gsl::not_null<const ::ioda::detail::Type_Provider*>(getTypeProvider()));
       auto att                = create(attrname, in_memory_dataType, dimensions);
       return att;
     } catch (...) {

--- a/src/engines/ioda/include/ioda/Variables/Has_Variables.h
+++ b/src/engines/ioda/include/ioda/Variables/Has_Variables.h
@@ -309,7 +309,7 @@ public:
     try {
       VariableCreationParameters params2 = params;
       FillValuePolicies::applyFillValuePolicy<DataType>(getFillValuePolicy(), params2.fillValue_);
-      Type in_memory_dataType = Types::GetType<DataType>(getTypeProvider());
+      Type in_memory_dataType = Types::GetType<DataType>(gsl::not_null<const ::ioda::detail::Type_Provider*>(getTypeProvider()));
       auto var                = create(name, in_memory_dataType, dimensions,
         max_dimensions, params2);
       return var;
@@ -343,7 +343,7 @@ public:
                             const VariableCreationParameters& params
                             = VariableCreationParameters::defaulted<DataType>()) {
     try {
-      Type in_memory_dataType = Types::GetType<DataType>(getTypeProvider());
+      Type in_memory_dataType = Types::GetType<DataType>(gsl::not_null<const ::ioda::detail::Type_Provider*>(getTypeProvider()));
 
       NewVariables_t newvars{NewVariable(name, in_memory_dataType, dimension_scales, params)};
       createWithScales(newvars);

--- a/src/engines/ioda/include/ioda/Variables/Variable.h
+++ b/src/engines/ioda/include/ioda/Variables/Variable.h
@@ -100,7 +100,7 @@ public:
   /// \throws ioda::Exception if an error occurred.
   template <class DataType>
   bool isA() const {
-    Type templateType = Types::GetType_Wrapper<DataType>::GetType(getTypeProvider());
+    Type templateType = Types::GetType_Wrapper<DataType>::GetType(gsl::not_null<const ::ioda::detail::Type_Provider*>(getTypeProvider()));
 
     return isA(templateType);
   }
@@ -108,7 +108,7 @@ public:
   virtual bool isA(Type lhs) const;
 
   /// Python compatability function
-  inline bool isA(BasicTypes dataType) const { return isA(Type(dataType, getTypeProvider())); }
+  inline bool isA(BasicTypes dataType) const { return isA(Type(dataType, gsl::not_null<::ioda::detail::Type_Provider*>(getTypeProvider()))); }
   /// \internal pybind11
   inline bool _py_isA2(BasicTypes dataType) { return isA(dataType); }
   /// Convenience function to query type
@@ -293,7 +293,7 @@ public:
       return write(gsl::make_span<const char>(
                       reinterpret_cast<const char*>(d->DataPointers.data()),
                      d->DataPointers.size() * Marshaller::bytesPerElement_),
-                   TypeWrapper::GetType(getTypeProvider()), mem_selection, file_selection);
+                   TypeWrapper::GetType(gsl::not_null<const ::ioda::detail::Type_Provider*>(getTypeProvider())), mem_selection, file_selection);
     } catch (...) {
       std::throw_with_nested(Exception(ioda_Here()));
     }
@@ -309,7 +309,7 @@ public:
       return parallelWrite(gsl::make_span<const char>(
                       reinterpret_cast<const char*>(d->DataPointers.data()),
                      d->DataPointers.size() * Marshaller::bytesPerElement_),
-                   TypeWrapper::GetType(getTypeProvider()), mem_selection, file_selection);
+                   TypeWrapper::GetType(gsl::not_null<const ::ioda::detail::Type_Provider*>(getTypeProvider())), mem_selection, file_selection);
     } catch (...) {
       std::throw_with_nested(Exception(ioda_Here()));
     }
@@ -339,7 +339,7 @@ public:
       return write(gsl::make_span<const char>(
                       reinterpret_cast<const char*>(d->DataPointers.data()),
                      d->DataPointers.size() * Marshaller::bytesPerElement_),
-                   TypeWrapper::GetType(getTypeProvider()), mem_selection, file_selection);
+                   TypeWrapper::GetType(gsl::not_null<const ::ioda::detail::Type_Provider*>(getTypeProvider())), mem_selection, file_selection);
     } catch (...) {
       std::throw_with_nested(Exception(ioda_Here()));
     }
@@ -355,7 +355,7 @@ public:
       return parallelWrite(gsl::make_span<const char>(
                       reinterpret_cast<const char*>(d->DataPointers.data()),
                      d->DataPointers.size() * Marshaller::bytesPerElement_),
-                   TypeWrapper::GetType(getTypeProvider()), mem_selection, file_selection);
+                   TypeWrapper::GetType(gsl::not_null<const ::ioda::detail::Type_Provider*>(getTypeProvider())), mem_selection, file_selection);
     } catch (...) {
       std::throw_with_nested(Exception(ioda_Here()));
     }
@@ -531,7 +531,7 @@ public:
              // reading in a string, then mutable data type is char*,
              // which works because address pointers have the same size.
              p->DataPointers.size() * Marshaller::bytesPerElement_),
-           TypeWrapper::GetType(getTypeProvider()), mem_selection, file_selection);
+           TypeWrapper::GetType(gsl::not_null<const ::ioda::detail::Type_Provider*>(getTypeProvider())), mem_selection, file_selection);
       m.deserialize(p, data, &atts);
 
       return Variable_Implementation{backend_};

--- a/src/engines/ioda/src/ioda/C/ioda_variable_c.cpp
+++ b/src/engines/ioda/src/ioda/C/ioda_variable_c.cpp
@@ -302,7 +302,8 @@ bool ioda_variable_c_write_char(ioda_variable_t p,int64_t n,const char * vptr) {
              throw std::exception();      
         }
         std::string s(str,n);
-        auto v = var->write< std::string >(s);  
+        std::vector<std::string> vs = {s};
+        auto v = var->write< std::string >(vs);  
         return true;
     } catch (std::exception& e) {
         std::cerr << "ioda_variable_c_write_char failed\n";
@@ -323,7 +324,7 @@ bool ioda_variable_c_write_str(ioda_variable_t p,cxx_vector_string_t vstr_p) {
            std::cerr << "ioda_variable_c_write_str vecstring pointer is null\n";
            fatal_error();					
        } 			
-       ioda::Variable v = var->write< std::vector< std::string > >(*vstr);
+       ioda::Variable v = var->write< std::string >(*vstr);
        return true;						
     } catch (std::exception& e) {				
         std::cerr << "ioda_variable_c_write_str_full failed ";
@@ -411,7 +412,7 @@ bool ioda_variable_c_read_str(void *p,int64_t n,cxx_vector_string_t *vstr) {
           vs_p = reinterpret_cast<void*>(new std::vector<std::string>()); 
        }  
        VOID_TO_CXX(std::vector<std::string>,vs_p,vs);
-       auto vr = var->read< std::vector<std::string> >(*vs);
+       auto vr = var->read< std::string >(*vs);
        // make sure that vstr points to correct char *
        *vstr = reinterpret_cast<void*>(vs);
        return true;

--- a/src/engines/ioda/src/ioda/Engines/HH/HH-groups.cpp
+++ b/src/engines/ioda/src/ioda/Engines/HH/HH-groups.cpp
@@ -178,10 +178,17 @@ std::map<ObjectType, std::vector<std::string>> HH_Group::listObjects(ObjectType 
 
   herr_t search_res
     = (recurse)
-        ? H5Lvisit(backend_(), idxclass, H5_ITER_NATIVE, iterate_find_by_link,
-                   reinterpret_cast<void*>(&iter_data))
-        : H5Literate(backend_(), idxclass, H5_ITER_NATIVE, 0, iterate_find_by_link,
-                     reinterpret_cast<void*>(&iter_data));  // NOLINT: 0 is not a nullptr here.
+#if H5_VERSION_GE(1, 12, 0)
+        ? H5Lvisit2(backend_(), idxclass, H5_ITER_NATIVE, iterate_find_by_link,
+                    reinterpret_cast<void*>(&iter_data))
+        : H5Literate2(backend_(), idxclass, H5_ITER_NATIVE, 0, iterate_find_by_link,
+                      reinterpret_cast<void*>(&iter_data));  // NOLINT: 0 is not a nullptr here.
+#else
+        ? H5Lvisit1(backend_(), idxclass, H5_ITER_NATIVE, iterate_find_by_link,
+                    reinterpret_cast<void*>(&iter_data))
+        : H5Literate1(backend_(), idxclass, H5_ITER_NATIVE, 0, iterate_find_by_link,
+                      reinterpret_cast<void*>(&iter_data));  // NOLINT: 0 is not a nullptr here.
+#endif
 
   if (search_res < 0) throw Exception("H5Lvisit / H5Literate failed.", ioda_Here())
     .add("recurse", recurse);

--- a/src/engines/ioda/src/ioda/Engines/HH/HH/HH-variables.h
+++ b/src/engines/ioda/src/ioda/Engines/HH/HH/HH-variables.h
@@ -70,7 +70,7 @@ public:
   /// \returns <0 if an error occurred.
   template <class DataType>
   bool isA() const {
-    auto ttype = Types::GetType<DataType>(getTypeProvider());
+    auto ttype = Types::GetType<DataType>(gsl::not_null<const ::ioda::detail::Type_Provider*>(getTypeProvider()));
     return isA(ttype);
   }
 
@@ -86,7 +86,7 @@ public:
   /// \returns <0 if an error occurred.
   template <class DataType>
   bool isExactlyA() const {
-    auto ttype     = Types::GetType<DataType>(getTypeProvider());
+    auto ttype     = Types::GetType<DataType>(gsl::not_null<const ::ioda::detail::Type_Provider*>(getTypeProvider()));
     HH_hid_t otype = internalType();
     auto ret       = H5Tequal(ttype(), otype());
     if (ret < 0) throw Exception("Cannot check type equality. General failure.", ioda_Here());

--- a/src/engines/ioda/src/ioda/Has_Variables.cpp
+++ b/src/engines/ioda/src/ioda/Has_Variables.cpp
@@ -162,7 +162,7 @@ Variable Has_Variables_Base::_create_py(const std::string& name, BasicTypes data
                              const VariableCreationParameters& params
                              ) {
   try {
-    Type typ = Type(dataType, getTypeProvider());
+    Type typ = Type(dataType, gsl::not_null<::ioda::detail::Type_Provider*>(getTypeProvider()));
     if (dimension_scales.size()) {
       std::vector<Dimensions_t> c_d, m_d, chunking_hints;
 

--- a/src/engines/ioda/src/ioda/Type.cpp
+++ b/src/engines/ioda/src/ioda/Type.cpp
@@ -178,7 +178,7 @@ Type::Type(std::shared_ptr<detail::Type_Backend> b, std::type_index t)
     : Type_Base(b, b->provider_), as_type_index_(t) {}
 
 Type::Type(BasicTypes typ, gsl::not_null<::ioda::detail::Type_Provider*> t)
-    : Type_Base(nullptr, t.get()), as_type_index_(typeid(void)) {
+    : Type_Base(nullptr, static_cast<::ioda::detail::Type_Provider*>(t)), as_type_index_(typeid(void)) {
   static const std::map<BasicTypes, std::type_index> workable_types
     = {{BasicTypes::float_, typeid(float)},    // NOLINT: cpplint doesn't understand this!
        {BasicTypes::double_, typeid(double)},  // NOLINT

--- a/src/ioPool/ReaderPoolUtils.cpp
+++ b/src/ioPool/ReaderPoolUtils.cpp
@@ -1958,7 +1958,7 @@ void readerLoadSourceVarReplaceFill(const ReaderPoolBase & ioPool,
         [&](auto typeDiscriminator) {
             typedef decltype(typeDiscriminator) T;
             const Type srcType =
-                Types::GetType_Wrapper<T>::GetType(srcVar.getTypeProvider());
+                Types::GetType_Wrapper<T>::GetType(gsl::not_null<const ::ioda::detail::Type_Provider*>(srcVar.getTypeProvider()));
             srcVar.read(srcBuffer, srcType, srcSelect, srcSelect);
             const ioda::Dimensions_t numElements = srcVar.getDimensions().numElements;
             replaceFillWithMissing<T>(ioPool, srcVar, numElements, srcBuffer);
@@ -2016,7 +2016,7 @@ void readerSaveDestVar(const std::string & varName, const std::vector<char> & de
         [&](auto typeDiscriminator) {
             typedef decltype(typeDiscriminator) T;
             const Type destType =
-                    Types::GetType_Wrapper<T>::GetType(destVar.getTypeProvider());
+                    Types::GetType_Wrapper<T>::GetType(gsl::not_null<const ::ioda::detail::Type_Provider*>(destVar.getTypeProvider()));
             destVar.write(destBuffer, destType, destSelect, destSelect);
             },
             VarUtils::ThrowIfVariableIsOfUnsupportedType(varName));


### PR DESCRIPTION
## Description
This pull request introduces the necessary changes to add build support for the NVIDIA HPC SDK (NVHPC) compilers. The NVHPC suite enforces stricter type constraints and highlighted some version-dependent API usage that required updates for full compatibility.

## Code Changes

1. Stricter Type Enforcement: The NVHPC compiler does not allow certain implicit pointer conversions that other compilers permit. To resolve this, explicit casts and gsl::not_null wrappers have been added where Type_Provider pointers are used, ensuring type safety and satisfying the compiler.

2. HDF5 API Compatibility: Updated the HDF5 backend to handle API changes across different library versions. Based on the [HDF5 documentation](https://ess-dmsc.github.io/h5cpp/stable/api_reference/namespace_hdf5.html), the code now uses a preprocessor check to call the modern H5Lvisit2 and H5Literate2 functions for HDF5 versions 1.12.0 and higher, while maintaining backward compatibility with older versions.

3. Missing Linker Dependency: Added find_package(EXPAT REQUIRED) to the main CMakeLists.txt and linked the ioda_engines target against EXPAT::EXPAT. This resolves a linking error caused by a missing dependency.

## Changes In gsl-lite

Please refer to the link [https://github.com/gsl-lite/gsl-lite/pull/359](https://github.com/gsl-lite/gsl-lite/pull/359) for changes required in gsl-lite.