### PR TITLE
Bug fix: Add missing dependencies to ioda-import.cmake.in

### DIFF
--- a/cmake/ioda-import.cmake.in
+++ b/cmake/ioda-import.cmake.in
@@ -65,6 +65,15 @@ endif()
 if(@odc_FOUND@)
     find_dependency( odc 1.0.2 REQUIRED )
 endif()
+
+if(@bufr_FOUND@)
+    find_dependency( bufr 12.0.1 REQUIRED )
+endif()
+
+if(@bufr_query_FOUND@)
+    find_dependency( bufr_query 0.0.4 REQUIRED )
+endif()
+
 # Header-only. Not exposed.
 #find_dependency( Boost 1.64.0 )
 


### PR DESCRIPTION
## Description

IODA's `cmake/ioda-import.cmake.in` is missing the optional dependencies `bufr` and `bufr_query`. This PR fixes it, and the version numbers match what is currently in the top-level `CMakeLists.txt`. Discovered while building NEPTUNE-JEDI with spack-built IODA et al.

## Issue(s) addressed

None created.

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have run the unit tests before creating the PR~~
- [x] Tested successfully with spack-stack and NEPTUNE-JEDI
